### PR TITLE
Add print page coverage

### DIFF
--- a/test/page-objects/confirmation.page.js
+++ b/test/page-objects/confirmation.page.js
@@ -5,6 +5,10 @@ class ConfirmationPage extends Page {
     const el = await $('//h1/following-sibling::div[1]/strong')
     return await el.getText()
   }
+
+  async printSubmittedApplication() {
+    await $('=View / Print submitted application (opens in new tab)').click()
+  }
 }
 
 export default new ConfirmationPage()

--- a/test/page-objects/print.submitted.application.page.js
+++ b/test/page-objects/print.submitted.application.page.js
@@ -1,0 +1,70 @@
+import { Page } from './page.js'
+
+class PrintSubmittedApplicationPage extends Page {
+  async open() {
+    return super.open('/farm-payments/print-submitted-application')
+  }
+
+  async applicationNumber() {
+    return $('p.govuk-body strong').getText()
+  }
+
+  async totalAnnualPayment() {
+    return $('p.govuk-body-l strong').getText()
+  }
+
+  async landParcels() {
+    const cards = await $$('.govuk-summary-card')
+    const results = []
+
+    for (const card of cards) {
+      const title = await card.$('.govuk-summary-card__title').getText()
+
+      if (title.includes('Additional')) {
+        continue
+      }
+
+      const rows = await card.$$('.govuk-table__body .govuk-table__row')
+      const actions = []
+
+      for (const row of rows) {
+        const cells = await row.$$('.govuk-table__cell')
+        actions.push({
+          action: await cells[0].getText(),
+          quantity: await cells[1].getText(),
+          annualPayment: await cells[2].getText()
+        })
+      }
+
+      results.push({ title: title.trim(), actions })
+    }
+
+    return results
+  }
+
+  async additionalAnnualPayments() {
+    const cards = await $$('.govuk-summary-card')
+    const results = []
+
+    for (const card of cards) {
+      const title = await card.$('.govuk-summary-card__title').getText()
+      if (!title.includes('Additional')) {
+        continue
+      }
+
+      const rows = await card.$$('.govuk-table__body .govuk-table__row')
+
+      for (const row of rows) {
+        const cells = await row.$$('.govuk-table__cell')
+        results.push({
+          action: await cells[0].getText(),
+          annualPayment: await cells[1].getText()
+        })
+      }
+    }
+
+    return results
+  }
+}
+
+export default new PrintSubmittedApplicationPage()

--- a/test/specs/non-prod/print_submitted_application.js
+++ b/test/specs/non-prod/print_submitted_application.js
@@ -1,0 +1,120 @@
+import { browser, expect } from '@wdio/globals'
+
+import HomePage from 'page-objects/home.page.js'
+import ConfirmYourDetailsPage from 'page-objects/confirm.your.details.page.js'
+import ConfirmYourLandDetailsPage from 'page-objects/confirm.your.land.details.js'
+import SelectLandParcelsPage from 'page-objects/select.land.parcels.page.js'
+import ActionsPage from 'page-objects/select.actions.page.js'
+import ReviewTheActionsYouHaveSelectedPage from 'page-objects/review.the.actions.page.js'
+import SubmitYourApplicationPage from 'page-objects/submit.your.application.page.js'
+import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
+import LoginPage from 'page-objects/login.page.js'
+import YouMustHaveConsentPage from 'page-objects/you.must.have.consent.page.js'
+import ConfirmationPage from 'page-objects/confirmation.page.js'
+import PrintSubmittedApplicationPage from 'page-objects/print.submitted.application.page.js'
+import {
+  switchToNewTab,
+  getCurrentWindowHandle,
+  closeCurrentTabAndSwitch
+} from '~/test/utils/window.handler.js'
+
+describe('Print submitted application @cdp @dev @ci', () => {
+  const crn = '1102760349'
+  const sbi = '121428499'
+
+  before(async () => {
+    await HomePage.clearApplicationStateWithApi(crn, sbi)
+  })
+
+  after(async () => {
+    await HomePage.clearApplicationStateWithApi(crn, sbi)
+  })
+
+  it('Given the farmer submits an application', async () => {
+    await HomePage.open()
+    await LoginPage.login(crn)
+
+    await ConfirmYourDetailsPage.clickButton('Continue')
+    await ConfirmYouWillBeEligiblePage.clickButton('Continue')
+    await ConfirmYourLandDetailsPage.clickButton('Continue')
+
+    await SelectLandParcelsPage.selectRequiredLandParcel('SD5949-6060')
+    await SelectLandParcelsPage.clickButton('Continue')
+
+    await ActionsPage.selectRequiredAction('CMOR1')
+    await ActionsPage.selectRequiredAction('UPL1')
+    await SelectLandParcelsPage.clickButton('Continue')
+
+    await ReviewTheActionsYouHaveSelectedPage.doYouWantToAddAnotherAction(
+      'true'
+    )
+    await ReviewTheActionsYouHaveSelectedPage.clickButton('Continue')
+
+    await SelectLandParcelsPage.selectRequiredLandParcel('SD6352-1073')
+    await SelectLandParcelsPage.clickButton('Continue')
+
+    await ActionsPage.selectRequiredAction('UPL2')
+    await SelectLandParcelsPage.clickButton('Continue')
+
+    await ReviewTheActionsYouHaveSelectedPage.doYouWantToAddAnotherAction(
+      'false'
+    )
+    await ReviewTheActionsYouHaveSelectedPage.clickButton('Continue')
+
+    await YouMustHaveConsentPage.clickButton('Continue')
+
+    const submitButton = await SubmitYourApplicationPage.submitButton()
+    await submitButton.click()
+  })
+
+  it('When the farmer opens the print application page', async () => {
+    const submittedReferenceNumber = await ConfirmationPage.referenceNumber()
+    const tabHandle = await getCurrentWindowHandle()
+    await ConfirmationPage.printSubmittedApplication()
+    await switchToNewTab()
+    await expect(browser).toHaveUrl(
+      expect.stringContaining('/print-submitted-application')
+    )
+    await closeCurrentTabAndSwitch(tabHandle)
+
+    await PrintSubmittedApplicationPage.open()
+    await expect(PrintSubmittedApplicationPage.pageHeading).toHaveText(
+      'Farm payments application'
+    )
+    await expect(await PrintSubmittedApplicationPage.applicationNumber()).toBe(
+      submittedReferenceNumber
+    )
+  })
+
+  it('Then the selected land parcels and additional payments can be printed', async () => {
+    await expect(await PrintSubmittedApplicationPage.totalAnnualPayment()).toBe(
+      '£8,814.00'
+    )
+
+    const parcels = await PrintSubmittedApplicationPage.landParcels()
+
+    expect(parcels[0].title).toBe('Land parcel ID SD5949 6060')
+    expect(parcels[0].actions[0].action).toContain(
+      'Assess moorland and produce a written record: CMOR1'
+    )
+    expect(parcels[0].actions[0].quantity).toBe('681.6133')
+    expect(parcels[0].actions[0].annualPayment).toBe('£7,225.10')
+    expect(parcels[0].actions[1].quantity).toBe('2.7321')
+    expect(parcels[0].actions[1].annualPayment).toBe('£95.62')
+
+    expect(parcels[1].title).toBe('Land parcel ID SD6352 1073')
+    expect(parcels[1].actions[0].action).toContain(
+      'Low livestock grazing on moorland: UPL2'
+    )
+    expect(parcels[1].actions[0].quantity).toBe('13.7223')
+    expect(parcels[1].actions[0].annualPayment).toBe('£1,221.28')
+
+    const additionalPayments =
+      await PrintSubmittedApplicationPage.additionalAnnualPayments()
+
+    expect(additionalPayments[0].action).toContain(
+      'Assess moorland and produce a written record: CMOR1'
+    )
+    expect(additionalPayments[0].annualPayment).toBe('£272.00')
+  })
+})


### PR DESCRIPTION
- Extend existing test with coverage of new `print-submitted-application` page
- Page is currently feature-flagged behind `ENABLE_FARM_PAYMENTS_PRINT_APPLICATION_20260311` which is enabled in Dev and CI
- This requires the selected test is limited to @ci and @dev for the lifetime of the feature flag
- Coverage mostly limited to open page and asserting correctly loaded because extensive coverage in `grants-ui-acceptance-tests`
- More coverage added for land parcels in print page because not currently covered in `grants-ui-acceptance-tests` as land parcels not present in `example-grant-with-auth` although there is a ticket to do this