### PR TITLE
Reduce flakiness in Dev on logging in plus refactor

### DIFF
--- a/test/page-objects/home.page.js
+++ b/test/page-objects/home.page.js
@@ -1,6 +1,4 @@
 import { Page } from './page.js'
-import { getBackendAuthorizationToken } from '~/test/utils/backend-auth-helper.js'
-import { mintLockToken } from '~/test/utils/lock-token.js'
 
 class HomePage extends Page {
   async open() {
@@ -9,40 +7,6 @@ class HomePage extends Page {
 
   async clearApplicationState() {
     return super.open('/farm-payments/clear-application-state')
-  }
-
-  async clearApplicationStateWithApi(crn, sbi) {
-    // If RUN_ENV is not set or not 'local', use the environment backend URL
-    // Otherwise use the ephemeral test backend URL
-    const grantCode = 'farm-payments'
-    const backendUrl =
-      process.env.RUN_ENV !== 'local'
-        ? browser.options.baseBackendUrl
-        : `https://ephemeral-protected.api.${process.env.ENVIRONMENT}.cdp-int.defra.cloud/grants-ui-backend`
-    console.log('backendUrl: ', backendUrl)
-
-    // If RUN_ENV is not set or not 'local', use the headers without x-api-key
-    // Otherwise use the headers with x-api-key
-    const headers =
-      process.env.RUN_ENV !== 'local'
-        ? {
-            Authorization: `Bearer ${getBackendAuthorizationToken()}`,
-            'x-application-lock-owner': mintLockToken(crn, sbi, grantCode)
-          }
-        : {
-            'x-api-key': process.env.GRANTS_UI_BACKEND_API_KEY,
-            Authorization: `Bearer ${getBackendAuthorizationToken()}`,
-            'x-application-lock-owner': mintLockToken(crn, sbi, grantCode)
-          }
-
-    const response = await fetch(
-      `${backendUrl}/state?sbi=${sbi}&grantCode=${grantCode}`,
-      {
-        method: 'DELETE',
-        headers
-      }
-    )
-    await expect(response.status === 200 || response.status === 404).toBe(true)
   }
 }
 

--- a/test/specs/non-prod/actions_with_hefer_consent.e2e.js
+++ b/test/specs/non-prod/actions_with_hefer_consent.e2e.js
@@ -11,6 +11,7 @@ import SubmitYourApplicationPage from 'page-objects/submit.your.application.page
 import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
 import LoginPage from 'page-objects/login.page.js'
 import YouMustHaveConsentPage from 'page-objects/you.must.have.consent.page.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Actions that require HEFER Consent @cdp @ci @hefer', () => {
   describe('Given farmer is eligible for funding', () => {
@@ -22,7 +23,7 @@ describe('Actions that require HEFER Consent @cdp @ci @hefer', () => {
       const actionTwo = 'CMOR1'
 
       before(async () => {
-        await HomePage.clearApplicationStateWithApi(crn, sbi)
+        await Backend.deleteState(crn, sbi)
       })
 
       it('Then the farmer is shown the landing page', async () => {

--- a/test/specs/non-prod/actions_with_sssi_and_hefer_consent.e2e.js
+++ b/test/specs/non-prod/actions_with_sssi_and_hefer_consent.e2e.js
@@ -11,6 +11,7 @@ import SubmitYourApplicationPage from 'page-objects/submit.your.application.page
 import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
 import LoginPage from 'page-objects/login.page.js'
 import YouMustHaveConsentPage from 'page-objects/you.must.have.consent.page.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Actions that require SSSI and HEFER Consent @cdp @ci @hefer', () => {
   describe('Given farmer is eligible for funding', () => {
@@ -22,7 +23,7 @@ describe('Actions that require SSSI and HEFER Consent @cdp @ci @hefer', () => {
       const actionTwo = 'UPL2'
 
       before(async () => {
-        await HomePage.clearApplicationStateWithApi(crn, sbi)
+        await Backend.deleteState(crn, sbi)
       })
 
       it('Then the farmer is shown the landing page', async () => {

--- a/test/specs/non-prod/actions_with_sssi_consent.e2e.js
+++ b/test/specs/non-prod/actions_with_sssi_consent.e2e.js
@@ -11,6 +11,7 @@ import SubmitYourApplicationPage from 'page-objects/submit.your.application.page
 import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
 import LoginPage from 'page-objects/login.page.js'
 import YouMustHaveSssiConsentPage from 'page-objects/you.must.have.consent.page.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Actions that require SSSI Consent @cdp @ci @sssi', () => {
   describe('Given farmer is eligible for funding', () => {
@@ -25,7 +26,7 @@ describe('Actions that require SSSI Consent @cdp @ci @sssi', () => {
       const actionThree = 'UPL10'
 
       before(async () => {
-        await HomePage.clearApplicationStateWithApi(crn, sbi)
+        await Backend.deleteState(crn, sbi)
       })
 
       it('Then the farmer is shown the landing page', async () => {

--- a/test/specs/non-prod/application_amendment.js
+++ b/test/specs/non-prod/application_amendment.js
@@ -10,6 +10,7 @@ import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligi
 import LoginPage from 'page-objects/login.page.js'
 import ConfirmationPage from 'page-objects/confirmation.page.js'
 import Gas from '~/test/utils/gas.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Amend an application @ci', () => {
   const crn = '1102760349'
@@ -23,11 +24,11 @@ describe('Amend an application @ci', () => {
   let applicationAmendExpectationId
 
   before(async () => {
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
   })
 
   after(async () => {
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
     if (applicationAmendExpectationId) {
       await Gas.clearExpectation(applicationAmendExpectationId)
     }

--- a/test/specs/non-prod/cmor1_rule_validation.js
+++ b/test/specs/non-prod/cmor1_rule_validation.js
@@ -1,8 +1,8 @@
 import { browser, expect } from '@wdio/globals'
 
-import HomePage from 'page-objects/home.page.js'
 import ActionsPage from 'page-objects/select.actions.page.js'
 import { performActionSelection } from '~/test/utils/journey-helpers.js'
+import Backend from '~/test/utils/backend.js'
 
 afterEach(async () => {
   // Clear all cookies after each test
@@ -19,7 +19,7 @@ describe('CMOR1 action - land parcel has no intersection with the moorland data 
       const action = 'UPL1'
 
       before(async () => {
-        await HomePage.clearApplicationStateWithApi(crn, sbi)
+        await Backend.deleteState(crn, sbi)
       })
 
       await performActionSelection({ crn, sbi, parcel, action })

--- a/test/specs/non-prod/contact_details_validation.js
+++ b/test/specs/non-prod/contact_details_validation.js
@@ -3,6 +3,7 @@ import { browser, expect } from '@wdio/globals'
 import HomePage from 'page-objects/home.page.js'
 import LoginPage from 'page-objects/login.page.js'
 import ConfirmYourDetailsPage from 'page-objects/confirm.your.details.page.js'
+import Backend from '~/test/utils/backend.js'
 
 afterEach(async () => {
   // Sign out and then clear all cookies after each test
@@ -14,7 +15,7 @@ describe('Contact Details validation for a SBI @cdp @dev', () => {
   it('SBI 300000011 - Unstructured contact details are shown correctly', async () => {
     const crn = '1300000011'
     const sbi = '300000011'
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
 
     await HomePage.open()
     await LoginPage.login(crn)
@@ -48,7 +49,7 @@ describe('Contact Details validation for a SBI @cdp @dev', () => {
   it('SBI 300000001 - Structured contact details are shown correctly', async () => {
     const crn = '1300000001'
     const sbi = '300000001'
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
 
     await HomePage.open()
     await LoginPage.login(crn)
@@ -79,7 +80,7 @@ describe('Contact Details validation for a SBI @cdp @dev', () => {
   it('SBI 106440951 - Structured contact details are shown correctly', async () => {
     const crn = '1103019058'
     const sbi = '106440951'
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
 
     await HomePage.open()
     await LoginPage.login(crn)
@@ -116,7 +117,7 @@ describe('Contact Details validation for a SBI @cdp @dev', () => {
   it('SBI 107034848 - Structured contact details are shown correctly', async () => {
     const crn = '1103711172'
     const sbi = '107034848'
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
 
     await HomePage.open()
     await LoginPage.login(crn)

--- a/test/specs/non-prod/missing_details_validation.js
+++ b/test/specs/non-prod/missing_details_validation.js
@@ -3,6 +3,7 @@ import { browser, expect } from '@wdio/globals'
 import HomePage from 'page-objects/home.page.js'
 import LoginPage from 'page-objects/login.page.js'
 import ConfirmYourDetailsPage from 'page-objects/confirm.your.details.page.js'
+import Backend from '~/test/utils/backend.js'
 
 afterEach(async () => {
   // Sign out and then clear all cookies after each test
@@ -15,7 +16,7 @@ describe('Missing Personal Details or Business details for a Farmer @cdp @ci @de
     it('Then farmer is shown validation message and not allowed to complete the application', async () => {
       const crn = '1400000008'
       const sbi = '400000008'
-      await HomePage.clearApplicationStateWithApi(crn, sbi)
+      await Backend.deleteState(crn, sbi)
 
       await HomePage.open()
       await LoginPage.login(crn)
@@ -30,7 +31,7 @@ describe('Missing Personal Details or Business details for a Farmer @cdp @ci @de
     it('Then farmer is shown validation message and not allowed to complete the application', async () => {
       const crn = '1400000006'
       const sbi = '400000006'
-      await HomePage.clearApplicationStateWithApi(crn, sbi)
+      await Backend.deleteState(crn, sbi)
 
       await HomePage.open()
       await LoginPage.login(crn)
@@ -45,7 +46,7 @@ describe('Missing Personal Details or Business details for a Farmer @cdp @ci @de
     it('Then farmer is shown validation message and not allowed to complete the application', async () => {
       const crn = '1400000002'
       const sbi = '400000002'
-      await HomePage.clearApplicationStateWithApi(crn, sbi)
+      await Backend.deleteState(crn, sbi)
 
       await HomePage.open()
       await LoginPage.login(crn)
@@ -60,7 +61,7 @@ describe('Missing Personal Details or Business details for a Farmer @cdp @ci @de
     it('Then the farmer is redirected back to confirm-farm-details page', async () => {
       const crn = '1400000008'
       const sbi = '400000008'
-      await HomePage.clearApplicationStateWithApi(crn, sbi)
+      await Backend.deleteState(crn, sbi)
 
       await HomePage.open()
       await LoginPage.login(crn)

--- a/test/specs/non-prod/print_submitted_application.js
+++ b/test/specs/non-prod/print_submitted_application.js
@@ -17,17 +17,18 @@ import {
   getCurrentWindowHandle,
   closeCurrentTabAndSwitch
 } from '~/test/utils/window.handler.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Print submitted application @cdp @dev @ci', () => {
   const crn = '1102760349'
   const sbi = '121428499'
 
   before(async () => {
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
   })
 
   after(async () => {
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
   })
 
   it('Given the farmer submits an application', async () => {

--- a/test/specs/non-prod/select_back_links.e2e.js
+++ b/test/specs/non-prod/select_back_links.e2e.js
@@ -1,9 +1,9 @@
 import { browser, expect } from '@wdio/globals'
 
-import HomePage from 'page-objects/home.page.js'
 import SelectLandParcelsPage from 'page-objects/select.land.parcels.page.js'
 import ReviewTheActionsYouHaveSelectedPage from 'page-objects/review.the.actions.page.js'
 import { performActionSelection } from '~/test/utils/journey-helpers.js'
+import Backend from '~/test/utils/backend.js'
 import { SERVICE_NAME } from '~/test/utils/config.js'
 
 const crn = '1103623923'
@@ -23,7 +23,7 @@ describe('Selecting back link through the journey @cdp @ci @dev', () => {
       const expectedActionText =
         'Assess moorland and produce a written record: CMOR1'
 
-      await HomePage.clearApplicationStateWithApi(crn, sbi)
+      await Backend.deleteState(crn, sbi)
       await performActionSelection({
         crn,
         sbi,

--- a/test/specs/non-prod/select_multiple_actions.e2e.js
+++ b/test/specs/non-prod/select_multiple_actions.e2e.js
@@ -10,6 +10,7 @@ import { SERVICE_NAME } from '~/test/utils/config.js'
 import SubmitYourApplicationPage from 'page-objects/submit.your.application.page.js'
 import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
 import LoginPage from 'page-objects/login.page.js'
+import Backend from '~/test/utils/backend.js'
 
 describe('Multiple actions selection and funding details verification @cdp @ci', () => {
   describe('Given farmer is eligible for funding', () => {
@@ -23,7 +24,7 @@ describe('Multiple actions selection and funding details verification @cdp @ci',
       const actionTwo = 'UPL2'
 
       before(async () => {
-        await HomePage.clearApplicationStateWithApi(crn, sbi)
+        await Backend.deleteState(crn, sbi)
       })
 
       it('Then the farmer is shown the landing page', async () => {

--- a/test/specs/non-prod/select_single_action.e2e.js
+++ b/test/specs/non-prod/select_single_action.e2e.js
@@ -10,6 +10,7 @@ import { SERVICE_NAME } from '~/test/utils/config.js'
 import ConfirmYourDetailsPage from 'page-objects/confirm.your.details.page.js'
 import SubmitYourApplicationPage from 'page-objects/submit.your.application.page.js'
 import ConfirmYouWillBeEligiblePage from 'page-objects/confirm.you.will.be.eligible.page'
+import Backend from '~/test/utils/backend.js'
 
 const testCases = [
   {
@@ -38,7 +39,8 @@ describe('Single action selection and funding details verification @cdp @ci', ()
     describe(`Given farmer applies only for ${action}${tagStr}`.trim(), () => {
       describe('When farmer goes through the land grants application', () => {
         it('Then the farmer is shown the landing page', async () => {
-          await HomePage.clearApplicationStateWithApi(crn, sbi)
+          await browser.deleteAllCookies()
+          await Backend.deleteState(crn, sbi)
           await HomePage.open()
           await LoginPage.login(crn)
         })

--- a/test/specs/non-prod/tc_and_payments_link_validation.js
+++ b/test/specs/non-prod/tc_and_payments_link_validation.js
@@ -1,6 +1,5 @@
 import { browser, expect } from '@wdio/globals'
 
-import HomePage from 'page-objects/home.page.js'
 import SubmitYourApplicationPage from 'page-objects/submit.your.application.page.js'
 import { SERVICE_NAME } from '~/test/utils/config.js'
 import {
@@ -9,6 +8,7 @@ import {
   closeCurrentTabAndSwitch
 } from '~/test/utils/window.handler.js'
 import { performActionSelection } from '~/test/utils/journey-helpers.js'
+import Backend from '~/test/utils/backend.js'
 import ReviewTheActionsYouHaveSelectedPage from 'page-objects/review.the.actions.page.js'
 
 afterEach(async () => {
@@ -22,7 +22,7 @@ describe('When clicking the Payments link, Terms & Conditions link and Farm Paym
     const sbi = '121428499'
     const parcel = 'SD5949-6060'
     const action = 'CMOR1'
-    await HomePage.clearApplicationStateWithApi(crn, sbi)
+    await Backend.deleteState(crn, sbi)
 
     await performActionSelection({ crn, sbi, parcel, action })
     await ReviewTheActionsYouHaveSelectedPage.doYouWantToAddAnotherAction(

--- a/test/utils/backend.js
+++ b/test/utils/backend.js
@@ -1,0 +1,39 @@
+import { expect } from '@wdio/globals'
+import { getBackendAuthorizationToken } from '~/test/utils/backend-auth-helper.js'
+import { mintLockToken } from '~/test/utils/lock-token.js'
+
+const GRANT_CODE = 'farm-payments'
+
+const backendUrl = () =>
+  process.env.RUN_ENV !== 'local'
+    ? browser.options.baseBackendUrl
+    : `https://ephemeral-protected.api.${process.env.ENVIRONMENT}.cdp-int.defra.cloud/grants-ui-backend`
+
+class Backend {
+  async deleteState(crn, sbi) {
+    console.log('backendUrl: ', backendUrl())
+
+    const headers =
+      process.env.RUN_ENV !== 'local'
+        ? {
+            Authorization: `Bearer ${getBackendAuthorizationToken()}`,
+            'x-application-lock-owner': mintLockToken(crn, sbi, GRANT_CODE)
+          }
+        : {
+            'x-api-key': process.env.GRANTS_UI_BACKEND_API_KEY,
+            Authorization: `Bearer ${getBackendAuthorizationToken()}`,
+            'x-application-lock-owner': mintLockToken(crn, sbi, GRANT_CODE)
+          }
+
+    const response = await fetch(
+      `${backendUrl()}/state?sbi=${sbi}&grantCode=${GRANT_CODE}`,
+      {
+        method: 'DELETE',
+        headers
+      }
+    )
+    await expect(response.status === 200 || response.status === 404).toBe(true)
+  }
+}
+
+export default new Backend()


### PR DESCRIPTION
- Add pre-test cookie cleardown to shared CRN test which is failing to find login page reliably in Dev, suspect not logged out from other test using same creds
- Refactor the grants-ui-backend state cleardown out of page object for clarity