### PR TITLE
[codex] Enable feature-flagged suites in GitHub CI

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,3 +24,4 @@ jobs:
       - run: npm install
       - run: npm run format:check
       - run: npm run lint
+      - run: npm run test:config

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:local:stack": "npm run clean && node --env-file=.env.local.stack ./node_modules/@wdio/cli/bin/wdio.js run wdio.local.conf.js",
     "test:local:debug": "npm run clean && DEBUG=true wdio run wdio.local.conf.js",
     "test:github": "npm run clean && wdio run wdio.github.conf.js",
+    "test:config": "node --test test/config/*.test.js",
     "format": "prettier --write 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "git:pre-commit-hook": "npm run format:check && npm run lint",

--- a/test/config/wdio.github.conf.test.js
+++ b/test/config/wdio.github.conf.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+test('GitHub config includes UPL8 tagged CI suites by default', async () => {
+  const originalEnv = {
+    ENABLE_UPL_8_AND_10_20260303: process.env.ENABLE_UPL_8_AND_10_20260303,
+    ENABLE_LAND_GRANT_HEFER_20260219:
+      process.env.ENABLE_LAND_GRANT_HEFER_20260219,
+    ENABLE_LAND_GRANT_SSSI_20260122: process.env.ENABLE_LAND_GRANT_SSSI_20260122
+  }
+
+  delete process.env.ENABLE_UPL_8_AND_10_20260303
+  delete process.env.ENABLE_LAND_GRANT_HEFER_20260219
+  delete process.env.ENABLE_LAND_GRANT_SSSI_20260122
+
+  try {
+    const { config } = await import('../../wdio.github.conf.js')
+    const upl8SuiteTitle =
+      'Single action selection and funding details verification @cdp @ci Given farmer applies only for UPL8 @upl8'
+
+    assert.equal(config.mochaOpts.grep.test(upl8SuiteTitle), true)
+  } finally {
+    restoreEnv(originalEnv)
+  }
+})
+
+function restoreEnv(originalEnv) {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+      continue
+    }
+    process.env[key] = value
+  }
+}

--- a/wdio.github.conf.js
+++ b/wdio.github.conf.js
@@ -1,5 +1,11 @@
 import allure from 'allure-commandline'
-import { getMochaGrepOptsForEnv, getSpecsForEnv } from './wdio.specs.js'
+import {
+  ensureAllFeatureFlagsOn,
+  getMochaGrepOptsForEnv,
+  getSpecsForEnv
+} from './wdio.specs.js'
+
+ensureAllFeatureFlagsOn()
 
 const oneMinute = 60 * 1000
 

--- a/wdio.specs.js
+++ b/wdio.specs.js
@@ -18,7 +18,7 @@ const TAG_TO_FLAG = {
 
 /**
  * Set all TAG_TO_FLAG env vars to 'true' if not already set.
- * Call from wdio.ci.conf.js so CI runs all feature-flagged tests by default.
+ * Call from CI configs so CI runs all feature-flagged tests by default.
  */
 export function ensureAllFeatureFlagsOn() {
   for (const flag of Object.values(TAG_TO_FLAG)) {


### PR DESCRIPTION
## What changed

- Calls `ensureAllFeatureFlagsOn()` from `wdio.github.conf.js` so the standalone GitHub CI test run includes feature-flagged suites such as `@upl8` by default.
- Adds a small config-level regression test covering the GitHub WDIO grep behavior for the `@upl8` suite.
- Adds `npm run test:config` to the pull request workflow so this behavior is checked without needing to run the full browser suite.

## Why

The `@upl8` suite is mapped to `ENABLE_UPL_8_AND_10_20260303`. When that env var is absent, the shared grep helper excludes `@upl8`. `wdio.ci.conf.js` already enabled all feature-flagged suites by default, but `wdio.github.conf.js` did not, so `npm run test:github` could silently skip the UPL8 CI suite.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run test:config`